### PR TITLE
use dai for staking token

### DIFF
--- a/deploy/02-deploy-staking.js
+++ b/deploy/02-deploy-staking.js
@@ -5,18 +5,25 @@ const { verify } = require("../helper-functions")
 module.exports = async ({ getNamedAccounts, deployments }) => {
     const { deploy, log } = deployments
     const { deployer } = await getNamedAccounts()
-    const rewardToken = await deployments.get("RewardToken")
+    const rewardToken = await ethers.getContract("RewardToken")
+    const dai = await deployments.get("DAI")
+
     const waitBlockConfirmations = developmentChains.includes(network.name)
         ? 1
         : VERIFICATION_BLOCK_CONFIRMATIONS
     log("----------------------------------------------------")
-    const args = [rewardToken.address, rewardToken.address]
+    const args = [dai.address, rewardToken.address]
     const stakingDeployment = await deploy("Staking", {
         from: deployer,
         args: args,
         log: true,
         waitConfirmations: waitBlockConfirmations,
     })
+
+    // send all the reward tokens to the staking contract
+    const totalRewardTokenSupply = await rewardToken.totalSupply()
+    await rewardToken.approve(deployer, totalRewardTokenSupply)
+    await rewardToken.transferFrom(deployer, stakingDeployment.address, totalRewardTokenSupply)
 
     // Verify the deployment
     if (!developmentChains.includes(network.name) && process.env.ETHERSCAN_API_KEY) {

--- a/test/unit/staking.test.js
+++ b/test/unit/staking.test.js
@@ -29,7 +29,7 @@ const SECONDS_IN_A_YEAR = 31449600
           })
           describe("rewardPerToken", () => {
               it("Returns the reward amount of 1 token based time spent locked up", async () => {
-                  await rewardToken.approve(staking.address, stakeAmount)
+                  await dai.approve(staking.address, stakeAmount)
                   await staking.stake(stakeAmount)
                   await moveTime(SECONDS_IN_A_DAY)
                   await moveBlocks(1)
@@ -46,7 +46,7 @@ const SECONDS_IN_A_YEAR = 31449600
           })
           describe("stake", () => {
               it("Moves tokens from the user to the staking contract", async () => {
-                  await rewardToken.approve(staking.address, stakeAmount)
+                  await dai.approve(staking.address, stakeAmount)
                   await staking.stake(stakeAmount)
                   await moveTime(SECONDS_IN_A_DAY)
                   await moveBlocks(1)
@@ -57,13 +57,13 @@ const SECONDS_IN_A_YEAR = 31449600
           })
           describe("withdraw", () => {
               it("Moves tokens from the user to the staking contract", async () => {
-                  await rewardToken.approve(staking.address, stakeAmount)
+                  await dai.approve(staking.address, stakeAmount)
                   await staking.stake(stakeAmount)
                   await moveTime(SECONDS_IN_A_DAY)
                   await moveBlocks(1)
-                  const balanceBefore = await rewardToken.balanceOf(deployer.address)
+                  const balanceBefore = await dai.balanceOf(deployer.address)
                   await staking.withdraw(stakeAmount)
-                  const balanceAfter = await rewardToken.balanceOf(deployer.address)
+                  const balanceAfter = await dai.balanceOf(deployer.address)
                   const earned = await staking.earned(deployer.address)
                   const expectedEarned = "8600000"
                   assert.equal(expectedEarned, earned.toString())
@@ -72,7 +72,7 @@ const SECONDS_IN_A_YEAR = 31449600
           })
           describe("claimReward", () => {
               it("Users can claim their rewards", async () => {
-                  await rewardToken.approve(staking.address, stakeAmount)
+                  await dai.approve(staking.address, stakeAmount)
                   await staking.stake(stakeAmount)
                   await moveTime(SECONDS_IN_A_DAY)
                   await moveBlocks(1)


### PR DESCRIPTION
It is confusing that the staking.test.js has the DAI ERC20 variable, but DAI is actually not used in Staking. Currently staking and reward tokens are the same.

This pull request uses DAI as the staked token.

I used 

`const rewardToken = await ethers.getContract("RewardToken")`
instead of 
`const rewardToken = await deployments.get("RewardToken")`

because otherwise the deployemnt failed with `unknown function rewardToken.approve`
