### PR TITLE
Replaced msg.sender with _msgSender() in burn() function in CentralizedStableCoin.sol

### DIFF
--- a/contracts/stablecoins/CentralizedStableCoin.sol
+++ b/contracts/stablecoins/CentralizedStableCoin.sol
@@ -88,7 +88,7 @@ contract CentralizedStableCoin is ERC20Burnable, Ownable {
         if (balance < _amount) {
             revert CentralizedStableCoin__BurnAmountExceedsBalance();
         }
-        _burn(msg.sender, _amount);
+        _burn(_msgSender(), _amount);
     }
 
     /***************************/


### PR DESCRIPTION
In the original ERC20Burnable Openzeppelin Standard, _msgSender() is passed to _burn() function instead of msg.sender for meta transactions cases. Did the changes